### PR TITLE
Gap size and sequence clean-up

### DIFF
--- a/src/superpang/lib/Assembler.py
+++ b/src/superpang/lib/Assembler.py
@@ -77,7 +77,7 @@ class Assembler:
 
 
 ##    @profile
-    def __init__(self, fasta, ksize, threads, diskdb = None, debug = False):
+    def __init__(self, fasta, ksize, threads, diskdb = None, debug = False, gap_size = 1):
         """
         Build a De-Bruijn Graph from an input fasta file
         """
@@ -91,7 +91,7 @@ class Assembler:
 
         ### Read input sequences
         print_time('Reading sequences')
-        self.seqDict = read_fasta(fasta, ambigs = 'as_Ns', Ns = 'split')
+        self.seqDict = read_fasta(fasta, ambigs = 'as_Ns', Ns = 'split', gap_size = gap_size)
         nNs = len({name.split('_Nsplit_')[0] for name in self.seqDict})
         self.ref2name = list(self.seqDict)
         max_kmers = sum(len(seq) - self.ksize + 1 for seq in self.seqDict.values() if len(seq) > self.ksize)

--- a/src/superpang/lib/utils.py
+++ b/src/superpang/lib/utils.py
@@ -1,32 +1,32 @@
 from datetime import datetime
 import resource
+import re
 
-
-def read_fasta(fasta, ambigs = 'ignore', Ns = 'ignore', split_name = True):
+def read_fasta(fasta, ambigs = 'ignore', Ns = 'ignore', split_name = True, gap_size = 1):
     assert Ns in ('ignore', 'split')
     assert ambigs in ('ignore', 'as_Ns')
+    gap = 'N' * gap_size
     seqDict = {}
+    re_remove = re.compile(r'[\s.-]+')
     for seq in open(fasta).read().strip().lstrip('>').split('>'):
         name, seq = seq.split('\n',1)
         if split_name:
             name = name.split(' ')[0]
-        seq = seq.upper().replace('\n','').replace('.','').replace('-','').replace('U','A')
-        if ambigs == 'as_Ns': # just translate the
+        seq = seq.upper().sub(re_remove, '').replace('U','T')
+        if ambigs == 'as_Ns': # translate the ambiguities
             seq = fix_Ns(seq)
         s = 0
         if name in seqDict:
             raise Exception(f'Sequence "{name}" is duplicated in your input file')
-        if Ns == 'ignore':
+        if Ns == 'ignore' or gap not in seq:
             seqDict[name] = seq
         else:
-            if 'N' not in seq:
-                seqDict[name] = seq
-            else:
-                i = 0
-                for seq in seq.split('N'):
-                    if seq:
-                        seqDict[f'{name}_Nsplit_{i}'] = seq
-                        i += 1
+            i = 0
+            for seq in seq.split(gap):
+                seq = seq.strip('N')
+                if seq:
+                    seqDict[f'{name}_Nsplit_{i}'] = seq
+                    i += 1
     return seqDict
 
 

--- a/src/superpang/lib/utils.py
+++ b/src/superpang/lib/utils.py
@@ -12,7 +12,7 @@ def read_fasta(fasta, ambigs = 'ignore', Ns = 'ignore', split_name = True, gap_s
         name, seq = seq.split('\n',1)
         if split_name:
             name = name.split(' ')[0]
-        seq = seq.upper().sub(re_remove, '').replace('U','T')
+        seq = re.sub(re_remove, '', seq).upper().replace('U','T')
         if ambigs == 'as_Ns': # translate the ambiguities
             seq = fix_Ns(seq)
         s = 0

--- a/src/superpang/scripts/SuperPang.py
+++ b/src/superpang/scripts/SuperPang.py
@@ -324,7 +324,7 @@ def parse_args():
                         help = 'Minimum iterations for sequence correction')
     parser.add_argument('-k', '--ksize', type = int, default = 301,
                         help = 'Kmer size')
-    parser.add_argument('--gap_size', type = int, default = 1,
+    parser.add_argument('--gap-size', type = int, default = 1,
                         help = 'Minimum length of a stretch of "N"s to be considered a scaffolding gap')
     parser.add_argument('-l', '--minlen', type = int, default = 0,
                         help = 'Scaffold length cutoff')

--- a/src/superpang/scripts/SuperPang.py
+++ b/src/superpang/scripts/SuperPang.py
@@ -197,7 +197,7 @@ def main(args, uuid):
         input_minimap2 = input_combined          
 
     ### Assemble
-    contigs = Assembler(input_minimap2, args.ksize, args.threads, diskdb, args.debug).run(args.minlen, args.mincov, args.bubble_identity_threshold, args.genome_assignment_threshold, args.threads, args.debug)
+    contigs = Assembler(input_minimap2, args.ksize, args.threads, diskdb, args.debug, gap_size = args.gap_size).run(args.minlen, args.mincov, args.bubble_identity_threshold, args.genome_assignment_threshold, args.threads, args.debug)
     if args.keep_intermediate:
         prelim = {}
         with open(outputPre2origs_kept, 'w') as outfile:
@@ -324,6 +324,8 @@ def parse_args():
                         help = 'Minimum iterations for sequence correction')
     parser.add_argument('-k', '--ksize', type = int, default = 301,
                         help = 'Kmer size')
+    parser.add_argument('--gap_size', type = int, default = 1,
+                        help = 'Minimum length of a stretch of "N"s to be considered a scaffolding gap')
     parser.add_argument('-l', '--minlen', type = int, default = 0,
                         help = 'Scaffold length cutoff')
     parser.add_argument('-c', '--mincov', type = float, default = 0,
@@ -362,6 +364,7 @@ def parse_args():
                         help='Write results even if the output directory already exists')
     parser.add_argument('--debug', action='store_true',
                         help = 'Run additional sanity checks (increases execution time)')
+
     args = parser.parse_args()
     if args.assume_complete:
         args.checkm = None


### PR DESCRIPTION
This pull request fixes two issues in `read_fasta()` :

- `seq = seq.upper().replace('\n','').replace('.','').replace('-','').replace('U','A')` is not robust enough and replaces U>A instead of U>T
  - this is fixed by `re_remove = re.compile(r'[\s.-]+')` and `seq = seq.upper().sub(re_remove, '').replace('U','T')`
- `seq.split('N')` over-splits sequences as some Ns are genuine assembly ambiguities
  - this is fixed by the introduction of `gap_size` - the minimum size of a run of Ns to be considered a gap
